### PR TITLE
feat: promote record labels to metadata

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,14 @@ export class LoggingBunyan extends Writable {
       delete record.httpRequest;
     }
 
+    // If the record contains a labels property, promote it to the entry
+    // metadata.
+    // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
+    if (record.labels) {
+      entryMetadata.labels = record.labels;
+      delete record.labels;
+    }
+
     // record does not have index signature.
     // tslint:disable-next-line:no-any
     if ((record as any)[LOGGING_TRACE_KEY]) {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -117,6 +117,7 @@ interface StackdriverEntryMetadata {
   timestamp?: Date,
   severity?: string, // figure out the correct type later
   httpRequest?: HttpRequest,
+  labels?: {},
   trace?: {}
 }
 
@@ -187,7 +188,8 @@ interface BunyanLogRecord {
   serviceContext?: ServiceContext,
   level?: string,
   time?: Date,
-  httpRequest?: HttpRequest
+  httpRequest?: HttpRequest,
+  labels?: {}
 }
 
 interface StreamResponse {


### PR DESCRIPTION
BREAKING CHANGE. If the record contains a labels property, promote it to
the entry metadata. This allows label based filtering in the Logging UI.
https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry

Counterpart to  https://github.com/googleapis/nodejs-logging-winston/pull/23

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
