### PR TITLE
chore: release v0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/logging-bunyan",
   "description": "Stackdriver Logging stream for Bunyan",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {


### PR DESCRIPTION
The draft release notes are in the GitHub UI.