### PR TITLE
chore: run npm link before npm install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,8 +198,8 @@ jobs:
           name: Link the module being tested to the samples.
           command: |
             cd samples/
-            npm install
             npm link @google-cloud/logging-bunyan
+            npm install
             cd ..
           environment:
             NPM_CONFIG_PREFIX: /home/node/.npm-global


### PR DESCRIPTION
One more place to apply the same fix as in #48, this time to make samples tests work.