### PR TITLE
doc: fix link to HttpRequest message

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ logger.info({
 }, req.path);
 ```
 
-The `httpRequest` proprety must be a properly formatted [`HttpRequest`][http-request-message] message.
+The `httpRequest` proprety must be a properly formatted [`HttpRequest`][http-request-message] message. (Note: the linked protobuf documentation shows `snake_case` property names, but in JavaScript one needs to provide property names in `camelCase`.)
 
 ### Correlating Logs with Traces
 
@@ -181,7 +181,7 @@ See [LICENSE](https://github.com/googleapis/nodejs-logging-bunyan/blob/master/LI
 [product-docs]: https://cloud.google.com/logging/docs
 [shell_img]: http://gstatic.com/cloudssh/images/open-btn.png
 
-[http-request-message]: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest
+[http-request-message]: https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.type#google.logging.type.HttpRequest
 [error-reporting]: https://cloud.google.com/error-reporting/
 [@google-cloud/error-reporting]: https://www.npmjs.com/package/@google-cloud/error-reporting
 [uncaught]: https://nodejs.org/api/process.html#process_event_uncaughtexception


### PR DESCRIPTION
Since we are using a protobuf based transport, users need to format
according to the protobuf docs rather than the JSON/REST docs.

Ref: https://github.com/googleapis/nodejs-logging-winston/issues/93


