### PR TITLE
fix: the system tests use a custom log

### DIFF
--- a/system-test/logging-bunyan.ts
+++ b/system-test/logging-bunyan.ts
@@ -22,10 +22,14 @@ import * as types from '../src/types/core';
 const logging = require('@google-cloud/logging')();
 import {LoggingBunyan} from '../src/index';
 
+const LOG_NAME = 'bunyan_log_system_tests';
+
 describe('LoggingBunyan', () => {
   const WRITE_CONSISTENCY_DELAY_MS = 90000;
 
-  const loggingBunyan = new LoggingBunyan();
+  const loggingBunyan = new LoggingBunyan({
+    logName: LOG_NAME
+  });
   const logger = bunyan.createLogger({
     name: 'google-cloud-node-system-test',
     streams: [loggingBunyan.stream('info')],
@@ -123,7 +127,7 @@ describe('LoggingBunyan', () => {
     }, 10);
 
     setTimeout(() => {
-      const log = logging.log('bunyan_log');
+      const log = logging.log(LOG_NAME);
 
       log.getEntries(
           {

--- a/system-test/logging-bunyan.ts
+++ b/system-test/logging-bunyan.ts
@@ -27,9 +27,7 @@ const LOG_NAME = 'bunyan_log_system_tests';
 describe('LoggingBunyan', () => {
   const WRITE_CONSISTENCY_DELAY_MS = 90000;
 
-  const loggingBunyan = new LoggingBunyan({
-    logName: LOG_NAME
-  });
+  const loggingBunyan = new LoggingBunyan({logName: LOG_NAME});
   const logger = bunyan.createLogger({
     name: 'google-cloud-node-system-test',
     streams: [loggingBunyan.stream('info')],


### PR DESCRIPTION
The system tests write to the `bunyan_log_system_tests` log to
avoid conflicting with the sample tests.

Fixes: #49
