### PR TITLE
doc: fix usage of logger.info in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,15 +133,14 @@ If you wish to set the Stackdriver LogEntry `trace` property with a custom value
 ```js
 const bunyan = require('bunyan');
 // Node 6+
-const {LoggingBunyan} = require('@google-cloud/logging-bunyan');
+const {LoggingBunyan, LOGGING_TRACE_KEY} = require('@google-cloud/logging-bunyan');
 const loggingBunyan = LoggingBunyan();
 
 ...
 
 logger.info({
-  msg: 'Bunyan log entry with custom trace field',
-  [LoggingBunyan.LOGGING_TRACE_KEY]: 'custom-trace-value'
-});
+  [LOGGING_TRACE_KEY]: 'custom-trace-value'
+}, 'Bunyan log entry with custom trace field');
 ```
 
 ## Samples


### PR DESCRIPTION
Fixes #66

This fixes the misleading README example highlighted in issue above, using https://github.com/googleapis/nodejs-logging-bunyan/issues/66#issuecomment-397791037 as a reference, and that `LOGGING_TRACE_KEY` exists on module exports, not the `LoggingBunyan` class.

- [ ] Tests and linter pass
- [x] Appropriate docs were updated (if necessary)
