### PR TITLE
fix: fix linting errors in the samples

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -12,3 +12,4 @@ rules:
   eqeqeq: error
   no-warning-comments: warn
   node/no-unsupported-features: warn
+  node/no-unsupported-features/es-syntax: warn

--- a/samples/package.json
+++ b/samples/package.json
@@ -6,7 +6,7 @@
   "author": "Google Inc.",
   "repository": "googleapis/nodejs-logging-bunyan",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=7.6.0"
   },
   "scripts": {
     "system-test": "ava -T 1m --verbose system-test/*.test.js",

--- a/samples/package.json
+++ b/samples/package.json
@@ -6,7 +6,7 @@
   "author": "Google Inc.",
   "repository": "googleapis/nodejs-logging-bunyan",
   "engines": {
-    "node": ">=7.6.0"
+    "node": ">=6.0.0"
   },
   "scripts": {
     "system-test": "ava -T 1m --verbose system-test/*.test.js",


### PR DESCRIPTION
`eslint` was reporting the following error:
```
error  Async functions are not supported until Node.js 7.6.0. The configured version range is '>=6.0.0'  node/no-unsupported-features/es-syntax
```
This happened because `eslint` has a new `node/no-unsupported-features/es-syntax` that by default reports an error.

The error occurs because the samples use async/await, async/await is not available until Node >= 7.6.0, and the samples `package.json` specifies only Node >= 6.0 is required.

To fix the linting errors, the `node/no-unsupported-features/es-syntax` was configured to only issue a warning.

This was done, instead of updating the `package.json` to specify that Node >= 7.6.0 is required,   since the library `@google-cloud/logging-bunyan` library only requires Node >= 6.0.0.  It is only if you want to use async/await that Node >= 7.6.0 is required.