### PR TITLE
chore: pin to delay@3.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "bunyan": "^1.8.12",
     "codecov": "^3.0.2",
     "cpy-cli": "^2.0.0",
-    "delay": "^3.0.0",
+    "delay": "~3.0.0",
     "eslint": "^5.0.1",
     "eslint-config-prettier": "^3.0.0",
     "eslint-plugin-node": "^7.0.0",


### PR DESCRIPTION
There is an issue with delay@3.1.0 with the included types.  This
is being tracked at delay
[issue #32](https://github.com/sindresorhus/delay/issues/32) and
is preventing @google-cloud/logging-bunyan from compiling.

Until delay issue #32 is resolved, delay will be pinned to version
3.0.x.