### PR TITLE
chore(package): upgrade to delay@3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^2.3.0",
     "@types/bunyan": "^1.8.4",
-    "@types/delay": "^2.0.1",
     "@types/express": "^4.16.0",
     "@types/glob": "^5.0.35",
     "@types/mocha": "^5.2.3",
@@ -92,7 +91,7 @@
     "bunyan": "^1.8.12",
     "codecov": "^3.0.2",
     "cpy-cli": "^2.0.0",
-    "delay": "~3.0.0",
+    "delay": "^3.1.0",
     "eslint": "^5.0.1",
     "eslint-config-prettier": "^3.0.0",
     "eslint-plugin-node": "^7.0.0",

--- a/samples/package.json
+++ b/samples/package.json
@@ -22,7 +22,7 @@
     "@google-cloud/logging": "^2.0.0",
     "@google-cloud/nodejs-repo-tools": "^2.3.0",
     "ava": "^0.25.0",
-    "delay": "^3.0.0",
+    "delay": "^3.1.0",
     "execa": "^0.11.0",
     "got": "^9.0.0"
   }

--- a/system-test/test-middleware-express.ts
+++ b/system-test/test-middleware-express.ts
@@ -17,7 +17,7 @@
 /* AN EXAMPLE RATHER THAN A TEST AT THIS POINT */
 
 import * as assert from 'assert';
-import * as delay from 'delay';
+import delay from 'delay';
 
 import {express as elb} from '../src/index';
 


### PR DESCRIPTION
The package started shipping types as part of the official
package.  These are breaking changes w.r.t previous
`@types/delay` types.  We need to import the module differently
now for things to work correctly.