### PR TITLE
fix: doc string is malformed for jsdoc

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,76 @@ function getCurrentTraceFromAgent() {
   return `projects/${traceProjectId}/traces/${traceId}`;
 }
 
+/**
+ * This module provides support for streaming your Bunyan logs to
+ * [Stackdriver Logging](https://cloud.google.com/logging).
+ *
+ * @class
+ *
+ * @param {object} [options]
+ * @param {string} [options.logName] The name of the log that will receive
+ *     messages written to this bunyan stream. Default: `bunyan_Log`.
+ * @param {object} [options.resource] The monitored resource that the log
+ *     stream corresponds to. On Google Cloud Platform, this is detected
+ *     automatically, but you may optionally specify a specific monitored
+ *     resource. For more information, see the
+ *     [official documentation]{@link
+ * https://cloud.google.com/logging/docs/api/reference/rest/v2/MonitoredResource}
+ * @param {object} [options.serviceContext] For logged errors, we provide this
+ *     as the service context. For more information see
+ *     [this guide]{@link
+ * https://cloud.google.com/error-reporting/docs/formatting-error-messages} and
+ * the [official documentation]{@link
+ * https://cloud.google.com/error-reporting/reference/rest/v1beta1/ServiceContext}.
+ * @param {string} [options.serviceContext.service] An identifier of the
+ *     service, such as the name of the executable, job, or Google App Engine
+ *     service name.
+ * @param {string} [options.serviceContext.version] Represents the version of
+ *     the service.
+ * @param {string} [options.projectId] The project ID from the Google Cloud
+ *     Console, e.g. 'grape-spaceship-123'. We will also check the environment
+ *     variable `GCLOUD_PROJECT` for your project ID. If your app is running in
+ *     an environment which supports {@link
+ * https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application
+ * Application Default Credentials}, your project ID will be detected
+ * automatically.
+ * @param {string} [options.keyFilename] Full path to the a .json, .pem, or .p12
+ *     key downloaded from the Google Cloud Console. If you provide a path
+ *     to a JSON file, the `projectId` option above is not necessary. NOTE: .pem
+ *     and .p12 require you to specify the `email` option as well.
+ * @param {string} [options.email] Account email address. Required when using a
+ *     .pem or .p12 keyFilename.
+ * @param {object} [options.credentials] Credentials object.
+ * @param {string} [options.credentials.client_email]
+ * @param {string} [options.credentials.private_key]
+ * @param {boolean} [options.autoRetry=true] Automatically retry requests if the
+ *     response is related to rate limits or certain intermittent server errors.
+ *     We will exponentially backoff subsequent requests by default.
+ * @param {number} [options.maxRetries=3] Maximum number of automatic retries
+ *     attempted before returning the error.
+ * @param {constructor} [options.promise] Custom promise module to use instead
+ *     of native Promises.
+ *
+ * @example <caption>Import the client library</caption>
+ * const {LoggingBunyan} = require('@google-cloud/logging-bunyan');
+ *
+ * @example <caption>Create a client that uses <a
+ * href="https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application">Application
+ * Default Credentials (ADC)</a>:</caption> const loggingBunyan = new
+ * LoggingBunyan();
+ *
+ * @example <caption>Create a client with <a
+ * href="https://cloud.google.com/docs/authentication/production#obtaining_and_providing_service_account_credentials_manually">explicit
+ * credentials</a>:</caption> const loggingBunyan = new LoggingBunyan({
+ *   projectId: 'your-project-id',
+ *   keyFilename: '/path/to/keyfile.json'
+ * });
+ *
+ * @example <caption>include:samples/quickstart.js</caption>
+ * region_tag:logging_bunyan_quickstart
+ * Full quickstart example:
+ *
+ */
 export class LoggingBunyan extends Writable {
   private logName: string;
   private resource: types.MonitoredResource|undefined;
@@ -220,7 +290,8 @@ export class LoggingBunyan extends Writable {
   _writev(
       chunks: Array<{
         // tslint:disable-next-line:no-any
-        chunk: any; encoding: string;
+        chunk: any;
+        encoding: string;
       }>,
       callback?: Function) {
     const entries = chunks.map((request: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -290,8 +290,7 @@ export class LoggingBunyan extends Writable {
   _writev(
       chunks: Array<{
         // tslint:disable-next-line:no-any
-        chunk: any;
-        encoding: string;
+        chunk: any; encoding: string;
       }>,
       callback?: Function) {
     const entries = chunks.map((request: {

--- a/src/middleware/express.ts
+++ b/src/middleware/express.ts
@@ -30,9 +30,7 @@ export type LogObject = {
   [level in bunyan.LogLevelString]: (...args: any[]) => void;
 };
 
-export interface AnnotatedRequest extends Request {
-  log: LogObject;
-}
+export interface AnnotatedRequest extends Request { log: LogObject; }
 
 function makeLogFunction(
     level: bunyan.LogLevelString,

--- a/src/middleware/express.ts
+++ b/src/middleware/express.ts
@@ -30,7 +30,9 @@ export type LogObject = {
   [level in bunyan.LogLevelString]: (...args: any[]) => void;
 };
 
-export interface AnnotatedRequest extends Request { log: LogObject; }
+export interface AnnotatedRequest extends Request {
+  log: LogObject;
+}
 
 function makeLogFunction(
     level: bunyan.LogLevelString,


### PR DESCRIPTION
Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
