### PR TITLE
refactor(middleware): use common code from logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "presystem-test": "npm run compile",
     "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
     "system-test": "mocha build/system-test --timeout 600000",
-    "test": "nyc mocha build/test",
+    "test": "nyc mocha build/test build/test/middleware",
     "check": "gts check",
     "clean": "gts clean",
     "compile": "tsc -p .",
@@ -72,8 +72,7 @@
     "codecov": "nyc report --reporter=json && codecov -f .coverage/*.json"
   },
   "dependencies": {
-    "@google-cloud/logging": "^4.0.1",
-    "@opencensus/propagation-stackdriver": "^0.0.6"
+    "@google-cloud/logging": "^4.1.0"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "presystem-test": "npm run compile",
     "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
     "system-test": "mocha build/system-test --timeout 600000",
-    "test": "nyc mocha build/test build/test/middleware",
+    "test": "nyc mocha --recursive build/test",
     "check": "gts check",
     "clean": "gts clean",
     "compile": "tsc -p .",

--- a/samples/express.js
+++ b/samples/express.js
@@ -24,7 +24,7 @@ const express = require('express');
 
 async function startServer() {
   const {logger, mw} = await lb.express.middleware({
-    logName: 'samples_express'
+    logName: 'samples_express',
   });
   const app = express();
 

--- a/samples/express.js
+++ b/samples/express.js
@@ -23,7 +23,9 @@ const lb = require('@google-cloud/logging-bunyan');
 const express = require('express');
 
 async function startServer() {
-  const {logger, mw} = await lb.express.middleware();
+  const {logger, mw} = await lb.express.middleware({
+    logName: 'samples_express'
+  });
   const app = express();
 
   // Install the logging middleware. This ensures that a Bunyan-style `log`

--- a/samples/system-test/express.test.js
+++ b/samples/system-test/express.test.js
@@ -24,6 +24,9 @@ const {Logging} = require('@google-cloud/logging');
 const logging = new Logging();
 const got = require('got');
 
+const lb = require('@google-cloud/logging-bunyan');
+const {APP_LOG_SUFFIX} = lb.express;
+
 test.before(tools.checkCredentials);
 
 test.serial(`should write using bunyan`, async t => {
@@ -45,7 +48,7 @@ test.serial(`should write using bunyan`, async t => {
   await delay(10 * 1000);
 
   // Make sure the log was written to Stackdriver Logging.
-  const log = logging.log('bunyan_log');
+  const log = logging.log(`samples_express_${APP_LOG_SUFFIX}`);
   const entries = (await log.getEntries({pageSize: 1}))[0];
   t.is(entries.length, 1);
   const entry = entries[0];

--- a/system-test/test-middleware-express.ts
+++ b/system-test/test-middleware-express.ts
@@ -57,7 +57,7 @@ describe('express middleware', () => {
       const next = async () => {
         // At this point fakeRequest.log should have been installed.
         // tslint:disable-next-line:no-any
-        (fakeRequest as any as elb.AnnotatedRequest).log.info(LOG_MESSAGE);
+        (fakeRequest as any).log.info(LOG_MESSAGE);
 
         await delay(WRITE_CONSISTENCY_DELAY_MS);
 

--- a/test/middleware/test-express.ts
+++ b/test/middleware/test-express.ts
@@ -1,0 +1,96 @@
+/*!
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import * as proxyquire from 'proxyquire';
+
+// types-only import. Actual require is done through proxyquire below.
+import {MiddlewareOptions} from '../../src/middleware/express';
+
+const FAKE_PROJECT_ID = 'project-🦄';
+const FAKE_GENERATED_MIDDLEWARE = () => {};
+
+let passedOptions: MiddlewareOptions|undefined;
+
+class FakeLoggingBunyan {
+  // tslint:disable-next-line:no-any Doing "just enough" faking.
+  stackdriverLog: any;
+  constructor(options: MiddlewareOptions) {
+    passedOptions = options;
+    this.stackdriverLog = {
+      logging: {
+        auth: {
+          async getProjectId() {
+            return FAKE_PROJECT_ID;
+          }
+        }
+      }
+    };
+  }
+
+  // tslint:disable-next-line:no-any Doing "just enough" faking.
+  stream(level: any) {
+    return {level, type: 'raw', stream: this};
+  }
+}
+
+let passedProjectId: string|undefined;
+function fakeMakeMiddleware(
+    projectId: string, makeChildLogger: Function): Function {
+  passedProjectId = projectId;
+  return FAKE_GENERATED_MIDDLEWARE;
+}
+
+const {middleware, APP_LOG_SUFFIX} =
+    proxyquire('../../src/middleware/express', {
+      '../../src/index': {LoggingBunyan: FakeLoggingBunyan},
+      '@google-cloud/logging':
+          {middleware: {express: {makeMiddleware: fakeMakeMiddleware}}}
+    });
+
+describe('middleware/express', () => {
+  beforeEach(() => {
+    passedOptions = undefined;
+    passedProjectId = undefined;
+  });
+
+  it('should create and return a middleware', async () => {
+    const {mw} = await middleware();
+    assert.strictEqual(mw, FAKE_GENERATED_MIDDLEWARE);
+  });
+
+  it('should use default logName and level', async () => {
+    await middleware();
+    assert.ok(passedOptions);
+    assert.strictEqual(passedOptions!.logName, `bunyan_log_${APP_LOG_SUFFIX}`);
+    assert.strictEqual(passedOptions!.level, 'info');
+  });
+
+  it('should prefer user-provided logName and level', async () => {
+    const LOGNAME = '㏒';
+    const LEVEL = 'fatal';
+    const OPTIONS = {logName: LOGNAME, level: LEVEL};
+    await middleware(OPTIONS);
+    assert.ok(passedOptions);
+    assert.strictEqual(passedOptions!.logName, `${LOGNAME}_${APP_LOG_SUFFIX}`);
+    assert.strictEqual(passedOptions!.level, LEVEL);
+  });
+
+  it('should acquire the projectId and pass to makeMiddleware', async () => {
+    await middleware();
+    assert.strictEqual(passedProjectId, FAKE_PROJECT_ID);
+  });
+});


### PR DESCRIPTION
Start using refactored code from @g-c/logging.

