### PR TITLE
fix: Pin @types/sinon to last compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "proxyquire": "^2.0.1",
     "request": "^2.88.0",
     "source-map-support": "^0.5.6",
-    "typescript": "~3.1.0"
+    "typescript": "~3.1.0",
+    "@types/sinon": "5.0.5"
   },
   "peerDependencies": {
     "bunyan": "*"


### PR DESCRIPTION
@types/sinon had an update over the weekend which broke many of our tests. The *real* fix is [something like this](https://github.com/googleapis/nodejs-spanner/pull/441/files), but for now, this should fix our broken CI and give us some breathing room.