### PR TITLE
chore: the sample tests complete correctly

### DIFF
--- a/samples/express.js
+++ b/samples/express.js
@@ -48,8 +48,13 @@ async function startServer() {
   logger.info({port: 8080}, 'bonjour');
 
   // Start listening on the http server.
-  app.listen(8080, () => {
+  const server = app.listen(8080, () => {
     console.log('http server listening on port 8080');
+  });
+
+  app.get('/shutdown', (req, res) => {
+    res.sendStatus(200);
+    server.close();
   });
 }
 

--- a/samples/system-test/express.test.js
+++ b/samples/system-test/express.test.js
@@ -25,6 +25,8 @@ const logging = new Logging();
 const got = require('got');
 
 before(tools.checkCredentials);
+after(() => got('http://localhost:8080/shutdown'));
+
 const lb = require('@google-cloud/logging-bunyan');
 const {APP_LOG_SUFFIX} = lb.express;
 


### PR DESCRIPTION
The samples tests start an express server that is used during the
test.  Previously, this server was not properly shutdown causing
the tests to timeout.  Now the server is correctly shutdown after
the express tests to ensure the tests complete correctly.