### PR TITLE
fix: de-flake system tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
     "@types/node": "^10.3.6",
     "@types/proxyquire": "^1.3.28",
     "@types/request": "^2.48.1",
+    "@types/uuid": "^3.4.4",
+    "broken-link-checker-local": "^0.2.0",
     "bunyan": "^1.8.12",
     "codecov": "^3.0.2",
     "cpy-cli": "^2.0.0",
@@ -86,7 +88,7 @@
     "source-map-support": "^0.5.6",
     "teeny-request": "^3.11.0",
     "typescript": "~3.3.0",
-    "broken-link-checker-local": "^0.2.0"
+    "uuid": "^3.3.2"
   },
   "peerDependencies": {
     "bunyan": "*"

--- a/system-test/test-install.ts
+++ b/system-test/test-install.ts
@@ -111,7 +111,7 @@ async function main() {
   app.use(mw);
 }`,
     description: 'can be used with express',
-    dependencies: ['express'],
+    dependencies: ['express', 'bunyan'],
     devDependencies: ['@types/bunyan', '@types/express']
   }
 ];
@@ -200,7 +200,7 @@ async function main() {
   });
 }`,
     description: 'can be used with express',
-    dependencies: ['express'],
+    dependencies: ['express', 'bunyan'],
     devDependencies: []
   }
 ];


### PR DESCRIPTION
Ref: https://github.com/googleapis/nodejs-logging-winston/pull/265

1. Synchronize the system test with logging-winston. Use the same
   structure and reliable mechanism for polling.
2. Apply the timeout uniformly across the test.
3. Use unique serviceContext for the error reporting tests to ensure
   concurrent executions of the tests do no race.

