### PR TITLE
fix: do not promote record.labels if improper

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ property to be the [`LogEntry.labels`](https://cloud.google.com/logging/docs/ref
 than being one of the properties in the `payload` fields. This makes it easier to filter the logs in the UI using the labels.
 
 ```javascript
-logger.info({someKey: 'some value'}, 'test log message');
+logger.info({labels: {someKey: 'some value'}}, 'test log message');
 ```
 
 All the label values must be strings for this promotion to work.

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ than being one of the properties in the `payload` fields. This makes it easier t
 logger.info({labels: {someKey: 'some value'}}, 'test log message');
 ```
 
-All the label values must be strings for this promotion to work.
+All the label values must be strings for this automatic promotion to work. Otherwise the labels are left in the payload.
 
 ### Formatting Request Logs
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,18 @@ Make sure to add logs to your [uncaught exception][uncaught] and [unhandled reje
 
 You may also want to see the [@google-cloud/error-reporting][@google-cloud/error-reporting] module which provides direct access to the Error Reporting API.
 
+### LogEntry Labels
+
+If the bunyan log record contains a label property where all the values are strings, we automatically promote that
+property to be the [`LogEntry.labels`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry) value rather
+than being one of the properties in the `payload` fields. This makes it easier to filter the logs in the UI using the labels.
+
+```javascript
+logger.info({someKey: 'some value'}, 'test log message');
+```
+
+All the label values must be strings for this promotion to work.
+
 ### Formatting Request Logs
 
 To format your request logs you can provide a `httpRequest` property on the bunyan metadata you provide along with the log message. We will treat this as the [`HttpRequest`][http-request-message] message and Stackdriver logging will show this as a request log. Example:

--- a/src/index.ts
+++ b/src/index.ts
@@ -221,7 +221,8 @@ export class LoggingBunyan extends Writable {
     // If the record contains a labels property, promote it to the entry
     // metadata.
     // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
-    if (record.labels) {
+    const proper = LoggingBunyan.properLabels(record.labels);
+    if (record.labels && proper) {
       entryMetadata.labels = record.labels;
       delete record.labels;
     }
@@ -232,6 +233,17 @@ export class LoggingBunyan extends Writable {
     }
 
     return this.stackdriverLog.entry(entryMetadata, record);
+  }
+
+  // tslint:disable-next-line:no-any
+  static properLabels(labels: any) {
+    if (typeof labels !== 'object') return false;
+    for (const prop in labels) {
+      if (typeof labels[prop] !== 'string') {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**


### PR DESCRIPTION
We promote a bunyan record.labels property to the LogEntry.labels
property. This enables label based filtering to work auto-magically.

However, this can be problematic when the labels are not type correct
as per the logging proto requirements - specifically, the labels values
have to be strings.

Restrict the automatic promotion to happen only in the cases when
know that the labels are well-formatted.

Fixes: https://github.com/googleapis/nodejs-logging-bunyan/issues/265

