### PR TITLE
chore: allow custom port in samples tests

### DIFF
--- a/samples/express.js
+++ b/samples/express.js
@@ -43,13 +43,15 @@ async function startServer() {
     res.send('hello world');
   });
 
+  const port = process.env.PORT || 8080;
+
   // `logger` can be used as a global logger, one not correlated to any specific
   // request.
-  logger.info({port: 8080}, 'bonjour');
+  logger.info({port}, 'bonjour');
 
   // Start listening on the http server.
-  const server = app.listen(8080, () => {
-    console.log('http server listening on port 8080');
+  const server = app.listen(port, () => {
+    console.log(`http server listening on port ${port}`);
   });
 
   app.get('/shutdown', (req, res) => {

--- a/samples/system-test/express.test.js
+++ b/samples/system-test/express.test.js
@@ -23,7 +23,9 @@ const got = require('got');
 const {Logging} = require('@google-cloud/logging');
 const logging = new Logging();
 
-after(() => got('http://localhost:8080/shutdown'));
+const PORT = process.env.PORT || 8080;
+
+after(() => got(`http://localhost:${PORT}/shutdown`));
 
 const lb = require('@google-cloud/logging-bunyan');
 const {APP_LOG_SUFFIX} = lb.express;
@@ -40,7 +42,7 @@ describe('express samples', () => {
     await delay(10 * 1000);
 
     // Make an HTTP request to exercise a request logging path.
-    await got('http://localhost:8080/');
+    await got(`http://localhost:${PORT}/`);
 
     // Wait 10 seconds for logs to be written to stackdriver service.
     await delay(10 * 1000);


### PR DESCRIPTION
This allows multiple runs of the samples tests to occur on the
same machine at the same time to test for conflicts between
concurrently running tests.