### PR TITLE
test: fix error reporting system test race

### DIFF
--- a/system-test/errors-transport.ts
+++ b/system-test/errors-transport.ts
@@ -68,15 +68,6 @@ export class ErrorsApiTransport extends common.Service {
     });
   }
 
-  async deleteAllEvents(): Promise<void> {
-    const projectId = await this.getProjectId();
-    const options = {
-      uri: [API, projectId, 'events'].join('/'),
-      method: 'DELETE'
-    };
-    await this.request(options);
-  }
-
   async getAllGroups(): Promise<ErrorGroupStats[]> {
     const projectId = await this.getProjectId();
     const options = {

--- a/system-test/logging-bunyan.ts
+++ b/system-test/logging-bunyan.ts
@@ -148,10 +148,6 @@ describe('LoggingBunyan', function() {
     const ERROR_REPORTING_POLL_TIMEOUT = WRITE_CONSISTENCY_DELAY_MS;
     const errorsTransport = new ErrorsApiTransport();
 
-    after(async () => {
-      await errorsTransport.deleteAllEvents();
-    });
-
     it('reports errors when logging errors', async () => {
       const start = Date.now();
 


### PR DESCRIPTION
The system tests for error reporting were still not safe to run
concurrently. The issue is that at the end we were deleting all events
(there is no API to delete events selectively, AFAICT). This meant that
concurrent executions of the system tests against the same project could
clobber anothers logged errors.

This is consistent with the observed timeouts looking for events to
show up.

Fixes #267

