### PR TITLE
fix: add missing dep on google-auth-library

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "predocs-test": "npm run docs"
   },
   "dependencies": {
-    "@google-cloud/logging": "^4.1.0"
+    "@google-cloud/logging": "^4.1.0",
+    "google-auth-library": "^3.1.0"
   },
   "devDependencies": {
     "@google-cloud/common": "^0.31.0",


### PR DESCRIPTION
We use this at runtime.

Fixes: https://github.com/googleapis/nodejs-logging-bunyan/issues/277