### PR TITLE
feat: auto-detect service context

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import * as express from './middleware/express';
 // Export the express middleware as 'express'.
 export {express};
 
-const {Logging} = require('@google-cloud/logging');
+const {Logging, detectServiceContext} = require('@google-cloud/logging');
 
 import * as types from './types/core';
 
@@ -162,6 +162,18 @@ export class LoggingBunyan extends Writable {
       throw new Error(
           `If 'serviceContext' is specified then ` +
           `'serviceContext.service' is required.`);
+    }
+
+    /* Asynchrnously attempt to discover the service context. */
+    if (!this.serviceContext) {
+      detectServiceContext(this.stackdriverLog.logging.auth)
+          .then(
+              (serviceContext: types.ServiceContext) => {
+                this.serviceContext = serviceContext;
+              },
+              () => {
+                  /* swallow any errors. */
+              });
     }
   }
 

--- a/system-test/errors-transport.ts
+++ b/system-test/errors-transport.ts
@@ -16,8 +16,6 @@
 
 import * as common from '@google-cloud/common';
 import delay from 'delay';
-import * as r from 'request';  // types only
-import {teenyRequest} from 'teeny-request';
 
 const packageJson = require('../../package.json');
 
@@ -54,7 +52,6 @@ const ONE_HOUR_API = 'timeRange.period=PERIOD_1_HOUR';
 export class ErrorsApiTransport extends common.Service {
   constructor() {
     super({
-      requestModule: teenyRequest as typeof r,
       baseUrl: 'https://clouderrorreporting.googleapis.com/v1beta1',
       scopes: ['https://www.googleapis.com/auth/cloud-platform'],
       packageJson


### PR DESCRIPTION
When running on GCP environments, automatically detect service context
so that error reporting can correctly pick up errors.

Fixes: https://github.com/googleapis/nodejs-logging-bunyan/issues/135

