### PR TITLE
feat!: log messages > 250,000 bytes are now truncated

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "predocs-test": "npm run docs"
   },
   "dependencies": {
-    "@google-cloud/logging": "^5.0.0",
+    "@google-cloud/logging": "^5.5.2",
     "google-auth-library": "^5.0.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,6 +148,10 @@ export class LoggingBunyan extends Writable {
     this.serviceContext = options.serviceContext;
     this.stackdriverLog = new Logging(options).log(this.logName, {
       removeCircular: true,
+      // See: https://cloud.google.com/logging/quotas, a log size of
+      // 250,000 has been chosen to keep us comfortably within the
+      // 256,000 limit.
+      maxEntrySize: options.maxEntrySize || 250000,
     });
 
     // serviceContext.service is required by the Error Reporting

--- a/src/types/core.d.ts
+++ b/src/types/core.d.ts
@@ -76,6 +76,8 @@ export interface Options {
    * Defaults to `logging.googleapis.com`.
    */
   apiEndpoint?: string;
+  // An attempt will be made to truncate messages larger than maxEntrySize.
+  maxEntrySize?: number;
 }
 
 export interface MonitoredResource {

--- a/test/index.ts
+++ b/test/index.ts
@@ -152,7 +152,10 @@ describe('logging-bunyan', () => {
 
       assert.strictEqual(fakeLoggingOptions_, optionsWithoutLogName);
       assert.strictEqual(fakeLogName_, 'bunyan_log');
-      assert.deepStrictEqual(fakeLogOptions_, {removeCircular: true});
+      assert.deepStrictEqual(fakeLogOptions_, {
+        removeCircular: true,
+        maxEntrySize: 250000,
+      });
     });
 
     it('should not throw if a serviceContext is not specified', () => {


### PR DESCRIPTION
see: https://github.com/googleapis/nodejs-logging-winston/issues/190