### PR TITLE
test: retry tests that intermittently timeout

### DIFF
--- a/system-test/logging-bunyan.ts
+++ b/system-test/logging-bunyan.ts
@@ -47,7 +47,8 @@ describe('LoggingBunyan', function() {
     streams: [loggingBunyan.stream('info')],
   });
 
-  it('should properly write log entries', async () => {
+  it('should properly write log entries', async function() {
+    this.retries(3);
     const timestamp = new Date();
     const start = Date.now();
 
@@ -171,7 +172,8 @@ describe('LoggingBunyan', function() {
     const ERROR_REPORTING_POLL_TIMEOUT = WRITE_CONSISTENCY_DELAY_MS;
     const errorsTransport = new ErrorsApiTransport();
 
-    it('reports errors when logging errors', async () => {
+    it('reports errors when logging errors', async function() {
+      this.retries(3);
       const start = Date.now();
 
       const message = `an error at ${Date.now()}`;


### PR DESCRIPTION
Adds retry logic for a couple tests that are hitting a 90 second limit occasionally.