### PR TITLE
test: don't wait for specific message

### DIFF
--- a/samples/system-test/express.test.js
+++ b/samples/system-test/express.test.js
@@ -42,15 +42,16 @@ describe('express samples', () => {
     // Make an HTTP request to exercise a request logging path.
     await got(`http://localhost:${PORT}/`);
 
-    // Wait 10 seconds for logs to be written to stackdriver service.
-    await delay(10 * 1000);
+    // Wait 5 seconds for logs to be written to stackdriver service.
+    await delay(5 * 1000);
 
     // Make sure the log was written to Stackdriver Logging.
     const log = logging.log(`samples_express_${APP_LOG_SUFFIX}`);
     const entries = (await log.getEntries({pageSize: 1}))[0];
     assert.strictEqual(entries.length, 1);
     const entry = entries[0];
-    assert(entry.data.message);
+    // Ensure that a functional logger ws configured with the sample:
+    assert.strictEqual(entry.data.message);
     assert.ok(entry.metadata.trace, 'should have a trace property');
     assert.match(entry.metadata.trace, /projects\/.*\/traces\/.*/);
   });

--- a/samples/system-test/express.test.js
+++ b/samples/system-test/express.test.js
@@ -50,7 +50,7 @@ describe('express samples', () => {
     const entries = (await log.getEntries({pageSize: 1}))[0];
     assert.strictEqual(entries.length, 1);
     const entry = entries[0];
-    assert.strictEqual('this is an info log message', entry.data.message);
+    assert(entry.data.message);
     assert.ok(entry.metadata.trace, 'should have a trace property');
     assert.match(entry.metadata.trace, /projects\/.*\/traces\/.*/);
   });

--- a/samples/system-test/express.test.js
+++ b/samples/system-test/express.test.js
@@ -16,7 +16,7 @@
 
 const path = require('path');
 const {assert} = require('chai');
-const {describe, it, after} = require('mocha');
+const {describe, it, before, after} = require('mocha');
 const {spawn} = require('child_process');
 const delay = require('delay');
 const got = require('got');
@@ -29,7 +29,7 @@ const {APP_LOG_SUFFIX} = lb.express;
 
 describe('express samples', () => {
   after(() => got(`http://localhost:${PORT}/shutdown`));
-  it('should write using bunyan', async () => {
+  before(async () => {
     // Start the express server.
     spawn(process.execPath, ['express.js'], {
       cwd: path.join(__dirname, '..'),
@@ -38,6 +38,10 @@ describe('express samples', () => {
 
     // Wait 10 seconds for initialization and for server to start listening.
     await delay(10 * 1000);
+  });
+
+  it('should write using bunyan', async function() {
+    this.retries(3);
 
     // Make an HTTP request to exercise a request logging path.
     await got(`http://localhost:${PORT}/`);
@@ -50,8 +54,8 @@ describe('express samples', () => {
     const entries = (await log.getEntries({pageSize: 1}))[0];
     assert.strictEqual(entries.length, 1);
     const entry = entries[0];
+    assert.strictEqual('this is an info log message', entry.data.message);
     // Ensure that a functional logger ws configured with the sample:
-    assert(typeof entry.data.message === 'string');
     assert.ok(entry.metadata.trace, 'should have a trace property');
     assert.match(entry.metadata.trace, /projects\/.*\/traces\/.*/);
   });

--- a/samples/system-test/express.test.js
+++ b/samples/system-test/express.test.js
@@ -42,8 +42,8 @@ describe('express samples', () => {
     // Make an HTTP request to exercise a request logging path.
     await got(`http://localhost:${PORT}/`);
 
-    // Wait 5 seconds for logs to be written to stackdriver service.
-    await delay(5 * 1000);
+    // Wait 10 seconds for logs to be written to stackdriver service.
+    await delay(10 * 1000);
 
     // Make sure the log was written to Stackdriver Logging.
     const log = logging.log(`samples_express_${APP_LOG_SUFFIX}`);
@@ -51,7 +51,7 @@ describe('express samples', () => {
     assert.strictEqual(entries.length, 1);
     const entry = entries[0];
     // Ensure that a functional logger ws configured with the sample:
-    assert(entry.data.message);
+    assert(typeof entry.data.message === 'string');
     assert.ok(entry.metadata.trace, 'should have a trace property');
     assert.match(entry.metadata.trace, /projects\/.*\/traces\/.*/);
   });

--- a/samples/system-test/express.test.js
+++ b/samples/system-test/express.test.js
@@ -51,7 +51,7 @@ describe('express samples', () => {
     assert.strictEqual(entries.length, 1);
     const entry = entries[0];
     // Ensure that a functional logger ws configured with the sample:
-    assert.strictEqual(entry.data.message);
+    assert(entry.data.message);
     assert.ok(entry.metadata.trace, 'should have a trace property');
     assert.match(entry.metadata.trace, /projects\/.*\/traces\/.*/);
   });


### PR DESCRIPTION
waiting for a specific message to be in stackdriver is fragile, instead let's simply assert that our sample created a functional express server with logging.