### PR TITLE
feat: add spanId and traceSampled logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ export const LOGGING_SAMPLED_KEY = 'logging.googleapis.com/trace_sampled';
  * @google-cloud/trace-agent library in the LogEntry.trace field format of:
  * "projects/[PROJECT-ID]/traces/[TRACE-ID]".
  */
-function getCurrentTraceFromAgent() {
+export function getCurrentTraceFromAgent() {
   const agent = global._google_trace_agent;
   if (!agent || !agent.getCurrentContextId || !agent.getWriterProjectId) {
     return null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,9 +37,23 @@ const BUNYAN_TO_STACKDRIVER: Map<number, string> = new Map([
 /**
  * Key to use in the Bunyan payload to allow users to indicate a trace for the
  * request, and to store as an intermediate value on the log entry before it
- * gets written to the Stackdriver logging API.
+ * gets written to the Cloud Logging logging API.
  */
 export const LOGGING_TRACE_KEY = 'logging.googleapis.com/trace';
+
+/**
+ * Key to use in the Bunyan payload to allow users to indicate a spanId for the
+ * request, and to store as an intermediate value on the log entry before it
+ * gets written to the Cloud logging API.
+ */
+export const LOGGING_SPAN_KEY = 'logging.googleapis.com/spanId';
+
+/**
+ * Key to use in the Bunyan payload to allow users to indicate a traceSampled
+ * flag for the request, and to store as an intermediate value on the log entry
+ * before it gets written to the Cloud logging API.
+ */
+export const LOGGING_SAMPLED_KEY = 'logging.googleapis.com/trace_sampled';
 
 /**
  * Gets the current fully qualified trace ID when available from the
@@ -251,6 +265,16 @@ export class LoggingBunyan extends Writable {
       delete record[LOGGING_TRACE_KEY];
     }
 
+    if (record[LOGGING_SPAN_KEY]) {
+      entryMetadata.spanId = record[LOGGING_SPAN_KEY];
+      delete record[LOGGING_SPAN_KEY];
+    }
+
+    if (record[LOGGING_SAMPLED_KEY]) {
+      entryMetadata.traceSampled = record[LOGGING_SAMPLED_KEY];
+      delete record[LOGGING_SAMPLED_KEY];
+    }
+
     return this.stackdriverLog.entry(entryMetadata, record);
   }
 
@@ -352,3 +376,19 @@ module.exports.BUNYAN_TO_STACKDRIVER = BUNYAN_TO_STACKDRIVER;
  * @type {string}
  */
 module.exports.LOGGING_TRACE_KEY = LOGGING_TRACE_KEY;
+
+/**
+ * Value: `logging.googleapis.com/spanId`
+ *
+ * @name LoggingBunyan.LOGGING_SPAN_KEY
+ * @type {string}
+ */
+module.exports.LOGGING_SPAN_KEY = LOGGING_SPAN_KEY;
+
+/**
+ * Value: `logging.googleapis.com/trace_sampled`
+ *
+ * @name LoggingBunyan.LOGGING_SAMPLED_KEY
+ * @type {string}
+ */
+module.exports.LOGGING_SAMPLED_KEY = LOGGING_SAMPLED_KEY;

--- a/src/index.ts
+++ b/src/index.ts
@@ -270,7 +270,7 @@ export class LoggingBunyan extends Writable {
       delete record[LOGGING_SPAN_KEY];
     }
 
-    if (record[LOGGING_SAMPLED_KEY]) {
+    if (LOGGING_SAMPLED_KEY in record) {
       entryMetadata.traceSampled = record[LOGGING_SAMPLED_KEY];
       delete record[LOGGING_SAMPLED_KEY];
     }

--- a/src/middleware/express.ts
+++ b/src/middleware/express.ts
@@ -20,7 +20,7 @@ import {
 import * as bunyan from 'bunyan';
 import {GCPEnv} from 'google-auth-library';
 
-import {LOGGING_TRACE_KEY, LoggingBunyan} from '../index';
+import {LOGGING_TRACE_KEY, LOGGING_SPAN_KEY, LOGGING_SAMPLED_KEY, LoggingBunyan} from '../index';
 import * as types from '../types/core';
 
 export const APP_LOG_SUFFIX = 'applog';
@@ -77,8 +77,8 @@ export async function middleware(
       name: options.logName!,
       streams: [loggingBunyanReq.stream(options.level as types.LogLevel)],
     });
-    emitRequestLog = (httpRequest: HttpRequest, trace: string) => {
-      requestLogger.info({[LOGGING_TRACE_KEY]: trace, httpRequest});
+    emitRequestLog = (httpRequest: HttpRequest, trace: string, span?: string, sampled?: boolean) => {
+      requestLogger.info({[LOGGING_TRACE_KEY]: trace, [LOGGING_SPAN_KEY]: span, [LOGGING_SAMPLED_KEY]: sampled, httpRequest});
     };
   }
 
@@ -91,7 +91,7 @@ export async function middleware(
     ),
   };
 
-  function makeChildLogger(trace: string) {
-    return logger.child({[LOGGING_TRACE_KEY]: trace}, true /* simple child */);
+  function makeChildLogger(trace: string, span?: string, sampled?: boolean) {
+    return logger.child({[LOGGING_TRACE_KEY]: trace, [LOGGING_SPAN_KEY]: span}, true /* simple child */);
   }
 }

--- a/src/middleware/express.ts
+++ b/src/middleware/express.ts
@@ -20,7 +20,12 @@ import {
 import * as bunyan from 'bunyan';
 import {GCPEnv} from 'google-auth-library';
 
-import {LOGGING_TRACE_KEY, LOGGING_SPAN_KEY, LOGGING_SAMPLED_KEY, LoggingBunyan} from '../index';
+import {
+  LOGGING_TRACE_KEY,
+  LOGGING_SPAN_KEY,
+  LOGGING_SAMPLED_KEY,
+  LoggingBunyan,
+} from '../index';
 import * as types from '../types/core';
 
 export const APP_LOG_SUFFIX = 'applog';
@@ -77,8 +82,18 @@ export async function middleware(
       name: options.logName!,
       streams: [loggingBunyanReq.stream(options.level as types.LogLevel)],
     });
-    emitRequestLog = (httpRequest: HttpRequest, trace: string, span?: string, sampled?: boolean) => {
-      requestLogger.info({[LOGGING_TRACE_KEY]: trace, [LOGGING_SPAN_KEY]: span, [LOGGING_SAMPLED_KEY]: sampled, httpRequest});
+    emitRequestLog = (
+      httpRequest: HttpRequest,
+      trace: string,
+      span?: string,
+      sampled?: boolean
+    ) => {
+      requestLogger.info({
+        [LOGGING_TRACE_KEY]: trace,
+        [LOGGING_SPAN_KEY]: span,
+        [LOGGING_SAMPLED_KEY]: sampled,
+        httpRequest,
+      });
     };
   }
 
@@ -92,6 +107,9 @@ export async function middleware(
   };
 
   function makeChildLogger(trace: string, span?: string, sampled?: boolean) {
-    return logger.child({[LOGGING_TRACE_KEY]: trace, [LOGGING_SPAN_KEY]: span}, true /* simple child */);
+    return logger.child(
+      {[LOGGING_TRACE_KEY]: trace, [LOGGING_SPAN_KEY]: span},
+      true /* simple child */
+    );
   }
 }

--- a/src/types/core.d.ts
+++ b/src/types/core.d.ts
@@ -160,6 +160,8 @@ export interface StackdriverEntryMetadata {
   httpRequest?: HttpRequest;
   labels?: {};
   trace?: {};
+  spanId?: {};
+  traceSampled?: {};
 }
 
 export interface StackdriverLog {

--- a/system-test/test-middleware-express.ts
+++ b/system-test/test-middleware-express.ts
@@ -72,6 +72,9 @@ describe('express middleware', () => {
         assert.strictEqual(LOG_MESSAGE, entry.data.message);
         assert(entry.metadata.trace, 'should have a trace property');
         assert(entry.metadata.trace!.match(/projects\/.*\/traces\/.*/));
+        assert(entry.metadata.spanId, 'should have a span property');
+        assert(entry.metadata.spanId!.match(/^[0-9]*/));
+        assert.strictEqual(entry.metadata.traceSampled, false);
         done();
       };
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -442,8 +442,8 @@ describe('logging-bunyan', () => {
       (recordWithTrace as any)[loggingBunyanLib.LOGGING_SAMPLED_KEY] = false;
 
       loggingBunyan.stackdriverLog.entry = (
-          entryMetadata: types.StackdriverEntryMetadata,
-          record: string | types.BunyanLogRecord
+        entryMetadata: types.StackdriverEntryMetadata,
+        record: string | types.BunyanLogRecord
       ) => {
         assert.deepStrictEqual(entryMetadata, {
           resource: loggingBunyan.resource,

--- a/test/index.ts
+++ b/test/index.ts
@@ -412,6 +412,10 @@ describe('logging-bunyan', () => {
       // recordWithTrace does not have index signature.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (recordWithTrace as any)[loggingBunyanLib.LOGGING_TRACE_KEY] = 'trace1';
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (recordWithTrace as any)[loggingBunyanLib.LOGGING_SPAN_KEY] = 'span1';
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (recordWithTrace as any)[loggingBunyanLib.LOGGING_SAMPLED_KEY] = true;
 
       loggingBunyan.stackdriverLog.entry = (
         entryMetadata: types.StackdriverEntryMetadata,
@@ -422,6 +426,8 @@ describe('logging-bunyan', () => {
           timestamp: RECORD.time,
           severity: 'INFO',
           trace: 'trace1',
+          spanId: 'span1',
+          traceSampled: true,
         });
         assert.deepStrictEqual(record, RECORD);
         done();

--- a/test/index.ts
+++ b/test/index.ts
@@ -407,7 +407,7 @@ describe('logging-bunyan', () => {
       loggingBunyan.formatEntry_(recordWithLabels);
     });
 
-    it('should promote prefixed trace property to metadata', done => {
+    it('should promote prefixed trace properties to metadata', done => {
       const recordWithTrace = Object.assign({}, RECORD);
       // recordWithTrace does not have index signature.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -428,6 +428,28 @@ describe('logging-bunyan', () => {
           trace: 'trace1',
           spanId: 'span1',
           traceSampled: true,
+        });
+        assert.deepStrictEqual(record, RECORD);
+        done();
+      };
+
+      loggingBunyan.formatEntry_(recordWithTrace);
+    });
+
+    it('should promote a `false` traceSampled property to metadata', done => {
+      const recordWithTrace = Object.assign({}, RECORD);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (recordWithTrace as any)[loggingBunyanLib.LOGGING_SAMPLED_KEY] = false;
+
+      loggingBunyan.stackdriverLog.entry = (
+          entryMetadata: types.StackdriverEntryMetadata,
+          record: string | types.BunyanLogRecord
+      ) => {
+        assert.deepStrictEqual(entryMetadata, {
+          resource: loggingBunyan.resource,
+          timestamp: RECORD.time,
+          severity: 'INFO',
+          traceSampled: false,
         });
         assert.deepStrictEqual(record, RECORD);
         done();


### PR DESCRIPTION
Blocked: [Nodejs-logging release](https://github.com/googleapis/nodejs-logging/pull/1092)

Changes: 
- Users can now hardcode a spanId via `LOGGING_SPAN_KEY` when using Winston
- Middleware scenario: if span is detected from the request obj, it is propagated to makeChildLogger, and emitRequestLog capabilities, and span is included in the final child logs.
- export function `getCurrentTraceFromAgent`