### PR TITLE
fix: Update dependency @google-cloud/logging from 9.0.0 to 9.8.0

### DIFF
--- a/.readme-partials.yml
+++ b/.readme-partials.yml
@@ -137,7 +137,7 @@ body: |-
   The `LoggingBunyan` class creates an instance of `Logging` which creates the `Log` class from `@google-cloud/logging` package to write log entries. 
   The `Log` class writes logs asynchronously and there are cases when log entries cannot be written and an error is 
   thrown - if error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
-  to the `LoggingBunyan` constructor which will be used to initialize `Log` object with that callback like in example below:
+  to the `LoggingBunyan` constructor which will be used to initialize the `Log` object with that callback like in the example below:
 
   ```js
   // Imports the Google Cloud client library for Bunyan

--- a/.readme-partials.yml
+++ b/.readme-partials.yml
@@ -135,8 +135,8 @@ body: |-
 
   ### Error handling with a default callback
   The `LoggingBunyan` class creates an instance of `Logging` which creates the `Log` class from `@google-cloud/logging` package to write log entries. 
-  The `Log` class writes logs asynchronously and there are cases when log entries cannot be written and an error is 
-  thrown.  If the error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
+  The `Log` class writes logs asynchronously and there are cases when log entries cannot be written when it fails or an error is returned from Logging backend.
+  If the error is not handled, it could crash the application. One possible way to handle the error is to provide a default callback
   to the `LoggingBunyan` constructor which will be used to initialize the `Log` object with that callback like in the example below:
 
   ```js

--- a/.readme-partials.yml
+++ b/.readme-partials.yml
@@ -136,7 +136,6 @@ body: |-
   ### Error handling with a default callback
   The `LoggingBunyan` class creates an instance of `Logging` which creates the `Log` class from `@google-cloud/logging` package to write log entries. 
   The `Log` class writes logs asynchronously and there are cases when log entries cannot be written and an error is 
-  thrown - if error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
   thrown.  If the error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
   to the `LoggingBunyan` constructor which will be used to initialize the `Log` object with that callback like in the example below:
 

--- a/.readme-partials.yml
+++ b/.readme-partials.yml
@@ -132,3 +132,24 @@ body: |-
     [LOGGING_TRACE_KEY]: 'custom-trace-value'
   }, 'Bunyan log entry with custom trace field');
   ```
+
+  ### Error handling with a default callback
+  The `LoggingBunyan` class creates an instance of `Logging` which creates the `Log` class from `@google-cloud/logging` package to write log entries. 
+  The `Log` class writes logs asynchronously and there are cases when log entries cannot be written and an error is 
+  thrown - if error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
+  to the `LoggingBunyan` constructor which will be used to initialize `Log` object with that callback like in example below:
+
+  ```js
+  // Imports the Google Cloud client library for Bunyan
+  const {LoggingBunyan} = require('@google-cloud/logging-bunyan');
+  // Creates a client
+  const loggingWinston = new LoggingBunyan({
+    projectId: 'your-project-id',
+    keyFilename: '/path/to/key.json',
+    defaultCallback: err => {
+        if (err) {
+        console.log('Error occured: ' + err);
+        }
+    },
+  });
+  ```

--- a/.readme-partials.yml
+++ b/.readme-partials.yml
@@ -143,7 +143,7 @@ body: |-
   // Imports the Google Cloud client library for Bunyan
   const {LoggingBunyan} = require('@google-cloud/logging-bunyan');
   // Creates a client
-  const loggingWinston = new LoggingBunyan({
+  const loggingBunyan = new LoggingBunyan({
     projectId: 'your-project-id',
     keyFilename: '/path/to/key.json',
     defaultCallback: err => {

--- a/.readme-partials.yml
+++ b/.readme-partials.yml
@@ -136,7 +136,7 @@ body: |-
   ### Error handling with a default callback
   The `LoggingBunyan` class creates an instance of `Logging` which creates the `Log` class from `@google-cloud/logging` package to write log entries. 
   The `Log` class writes logs asynchronously and there are cases when log entries cannot be written and an error is 
-  thrown - if error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
+  thrown.  If the error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
   to the `LoggingBunyan` constructor which will be used to initialize the `Log` object with that callback like in the example below:
 
   ```js

--- a/README.md
+++ b/README.md
@@ -215,11 +215,10 @@ logger.info({
 }, 'Bunyan log entry with custom trace field');
 ```
 
-<<<<<<< HEAD
-=======
 ### Error handling with a default callback
 The `LoggingBunyan` class creates an instance of `Logging` which creates the `Log` class from `@google-cloud/logging` package to write log entries. 
 The `Log` class writes logs asynchronously and there are cases when log entries cannot be written and an error is 
+thrown - if error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
 thrown.  If the error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
 to the `LoggingBunyan` constructor which will be used to initialize the `Log` object with that callback like in the example below:
 
@@ -238,7 +237,6 @@ const loggingBunyan = new LoggingBunyan({
 });
 ```
 
->>>>>>> b8cf706e4ffe071054656f3b1933d8a6191601a1
 
 ## Samples
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ logger.info({
 The `LoggingBunyan` class creates an instance of `Logging` which creates the `Log` class from `@google-cloud/logging` package to write log entries. 
 The `Log` class writes logs asynchronously and there are cases when log entries cannot be written and an error is 
 thrown - if error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
-to the `LoggingBunyan` constructor which will be used to initialize `Log` object with that callback like in example below:
+to the `LoggingBunyan` constructor which will be used to initialize the `Log` object with that callback like in the example below:
 
 ```js
 // Imports the Google Cloud client library for Bunyan

--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ logger.info({
 
 ### Error handling with a default callback
 The `LoggingBunyan` class creates an instance of `Logging` which creates the `Log` class from `@google-cloud/logging` package to write log entries. 
-The `Log` class writes logs asynchronously and there are cases when log entries cannot be written and an error is 
-thrown.  If the error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
+The `Log` class writes logs asynchronously and there are cases when log entries cannot be written when it fails or an error is returned from Logging backend.
+If the error is not handled, it could crash the application. One possible way to handle the error is to provide a default callback
 to the `LoggingBunyan` constructor which will be used to initialize the `Log` object with that callback like in the example below:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ logger.info({
 ### Error handling with a default callback
 The `LoggingBunyan` class creates an instance of `Logging` which creates the `Log` class from `@google-cloud/logging` package to write log entries. 
 The `Log` class writes logs asynchronously and there are cases when log entries cannot be written and an error is 
-thrown - if error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
+thrown.  If the error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
 to the `LoggingBunyan` constructor which will be used to initialize the `Log` object with that callback like in the example below:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -215,6 +215,27 @@ logger.info({
 }, 'Bunyan log entry with custom trace field');
 ```
 
+### Error handling with a default callback
+The `LoggingBunyan` class creates an instance of `Logging` which creates the `Log` class from `@google-cloud/logging` package to write log entries. 
+The `Log` class writes logs asynchronously and there are cases when log entries cannot be written and an error is 
+thrown - if error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
+to the `LoggingBunyan` constructor which will be used to initialize `Log` object with that callback like in example below:
+
+```js
+// Imports the Google Cloud client library for Bunyan
+const {LoggingBunyan} = require('@google-cloud/logging-bunyan');
+// Creates a client
+const loggingBunyan = new LoggingBunyan({
+  projectId: 'your-project-id',
+  keyFilename: '/path/to/key.json',
+  defaultCallback: err => {
+      if (err) {
+      console.log('Error occured: ' + err);
+      }
+  },
+});
+```
+
 
 ## Samples
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,6 @@ logger.info({
 ### Error handling with a default callback
 The `LoggingBunyan` class creates an instance of `Logging` which creates the `Log` class from `@google-cloud/logging` package to write log entries. 
 The `Log` class writes logs asynchronously and there are cases when log entries cannot be written and an error is 
-thrown - if error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
 thrown.  If the error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
 to the `LoggingBunyan` constructor which will be used to initialize the `Log` object with that callback like in the example below:
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "precompile": "gts clean"
   },
   "dependencies": {
-    "@google-cloud/logging": "^9.0.0",
+    "@google-cloud/logging": "^9.8.0",
     "google-auth-library": "^7.0.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,6 +171,7 @@ export class LoggingBunyan extends Writable {
       // 250,000 has been chosen to keep us comfortably within the
       // 256,000 limit.
       maxEntrySize: options.maxEntrySize || 250000,
+      defaultWriteDeleteCallback: options.defaultCallback,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     }) as any;
 

--- a/src/middleware/express.ts
+++ b/src/middleware/express.ts
@@ -106,8 +106,7 @@ export async function middleware(
     ),
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  function makeChildLogger(trace: string, span?: string, sampled?: boolean) {
+  function makeChildLogger(trace: string, span?: string) {
     return logger.child(
       {[LOGGING_TRACE_KEY]: trace, [LOGGING_SPAN_KEY]: span},
       true /* simple child */

--- a/src/middleware/express.ts
+++ b/src/middleware/express.ts
@@ -106,6 +106,7 @@ export async function middleware(
     ),
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   function makeChildLogger(trace: string, span?: string, sampled?: boolean) {
     return logger.child(
       {[LOGGING_TRACE_KEY]: trace, [LOGGING_SPAN_KEY]: span},

--- a/src/types/core.d.ts
+++ b/src/types/core.d.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {ApiResponseCallback} from '@google-cloud/logging/build/src/log';
+
 export interface Options {
   /**
    * The name of the log that will receive messages written to this bunyan
@@ -78,6 +80,10 @@ export interface Options {
   apiEndpoint?: string;
   // An attempt will be made to truncate messages larger than maxEntrySize.
   maxEntrySize?: number;
+
+  // A default global callback to be used for {@link LoggingBunyan} write calls
+  // when callback is not supplied by caller in function parameters
+  defaultCallback?: ApiResponseCallback;
 }
 
 export interface MonitoredResource {

--- a/test/index.ts
+++ b/test/index.ts
@@ -148,6 +148,7 @@ describe('logging-bunyan', () => {
       assert.strictEqual(fakeLoggingOptions_, optionsWithoutLogName);
       assert.strictEqual(fakeLogName_, 'bunyan_log');
       assert.deepStrictEqual(fakeLogOptions_, {
+        defaultWriteDeleteCallback: undefined,
         removeCircular: true,
         maxEntrySize: 250000,
       });


### PR DESCRIPTION
This is a fix to expose a default callback from `Options` used by `LoggingBunyan` so it would be propagated to `Log` constructor from `@google-cloud/logging` npm package. Also, update `@google-cloud/logging` dependency to 9.6.9.

Fixes #[595](https://github.com/googleapis/nodejs-logging-bunyan/issues/595) and #[530](https://github.com/googleapis/nodejs-logging-bunyan/issues/530) 🦕