### PR TITLE
fix: Use defaultCallback in LoggingBunyan class

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -644,6 +644,28 @@ describe('logging-bunyan', () => {
 
       loggingBunyan._write(RECORD, '', done);
     });
+
+    it('should write the record and call default callback', done => {
+      let isCallbackCalled = false;
+      loggingBunyan.stackdriverLog.entry = () => {
+        return {};
+      };
+      loggingBunyan.defaultCallback = () => {
+        isCallbackCalled = true;
+      };
+      loggingBunyan.stackdriverLog.write =
+        // Writable.write used 'any' in function signature.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (entries: any, callback: Function) => {
+          callback();
+        };
+
+      loggingBunyan._write(RECORD, '', () => {
+        throw Error('Should never be called!');
+      });
+      assert.strictEqual(isCallbackCalled, true);
+      done();
+    });
   });
 
   describe('_writev', () => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -148,7 +148,6 @@ describe('logging-bunyan', () => {
       assert.strictEqual(fakeLoggingOptions_, optionsWithoutLogName);
       assert.strictEqual(fakeLogName_, 'bunyan_log');
       assert.deepStrictEqual(fakeLogOptions_, {
-        defaultWriteDeleteCallback: undefined,
         removeCircular: true,
         maxEntrySize: 250000,
       });


### PR DESCRIPTION
Error handling with a default global callback has an issue - bunyan library always uses default callback, so LoggingBunyan need to override it with default callback when provided.

Fixes #<595> 🦕
