### PR TITLE
feat: Logging provider for Cloud Functions that outputs structured logs to process.stdout

### DIFF
--- a/.readme-partials.yml
+++ b/.readme-partials.yml
@@ -153,3 +153,26 @@ body: |-
     },
   });
   ```
+
+  ### Alternative way to ingest logs in Google Cloud managed environments
+  If you use this library with the Cloud Logging Agent, you can configure the handler to output logs to `process.stdout` using
+  the [structured logging Json format](https://cloud.google.com/logging/docs/structured-logging#special-payload-fields).
+  To do this, add `redirectToStdout: true` parameter to the `LoggingBunyan` constructor as in sample below.
+  You can use this parameter when running applications in Google Cloud managed environments such as AppEngine, Cloud Run,
+  Cloud Function or GKE. The logger agent installed on these environments can capture `process.stdout` and ingest it into Cloud Logging.
+  The agent can parse structured logs printed to `process.stdout` and capture additional log metadata beside the log payload.
+  It is recommended to set `redirectToStdout: true` in serverless environments like Cloud Functions since it could 
+  decrease logging record loss upon execution termination - since all logs are written to `process.stdout` those
+  would be picked up by the Cloud Logging Agent running in Google Cloud managed environment. 
+
+  ```js
+  // Imports the Google Cloud client library for Bunyan
+  const {LoggingBunyan} = require('@google-cloud/logging-bunyan');
+
+  // Creates a client
+  const loggingBunyan = new LoggingBunyan({
+    projectId: 'your-project-id',
+    keyFilename: '/path/to/key.json',
+    redirectToStdout: true,
+  });
+  ```

--- a/README.md
+++ b/README.md
@@ -236,6 +236,29 @@ const loggingBunyan = new LoggingBunyan({
 });
 ```
 
+### Alternative way to ingest logs in Google Cloud managed environments
+If you use this library with the Cloud Logging Agent, you can configure the handler to output logs to `process.stdout` using
+the [structured logging Json format](https://cloud.google.com/logging/docs/structured-logging#special-payload-fields).
+To do this, add `redirectToStdout: true` parameter to the `LoggingBunyan` constructor as in sample below.
+You can use this parameter when running applications in Google Cloud managed environments such as AppEngine, Cloud Run,
+Cloud Function or GKE. The logger agent installed on these environments can capture `process.stdout` and ingest it into Cloud Logging.
+The agent can parse structured logs printed to `process.stdout` and capture additional log metadata beside the log payload.
+It is recommended to set `redirectToStdout: true` in serverless environments like Cloud Functions since it could 
+decrease logging record loss upon execution termination - since all logs are written to `process.stdout` those
+would be picked up by the Cloud Logging Agent running in Google Cloud managed environment. 
+
+```js
+// Imports the Google Cloud client library for Bunyan
+const {LoggingBunyan} = require('@google-cloud/logging-bunyan');
+
+// Creates a client
+const loggingBunyan = new LoggingBunyan({
+  projectId: 'your-project-id',
+  keyFilename: '/path/to/key.json',
+  redirectToStdout: true,
+});
+```
+
 
 ## Samples
 

--- a/src/middleware/express.ts
+++ b/src/middleware/express.ts
@@ -64,8 +64,8 @@ export async function middleware(
     name: `${options.logName}_${APP_LOG_SUFFIX}`,
     streams: [loggingBunyanApp.stream(options.level as types.LogLevel)],
   });
-
-  const auth = loggingBunyanApp.stackdriverLog.logging.auth;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const auth = (loggingBunyanApp.cloudLog as any).logging.auth;
   const [env, projectId] = await Promise.all([
     auth.getEnv(),
     auth.getProjectId(),

--- a/src/types/core.d.ts
+++ b/src/types/core.d.ts
@@ -79,11 +79,18 @@ export interface Options {
    */
   apiEndpoint?: string;
   // An attempt will be made to truncate messages larger than maxEntrySize.
+  // Please note that this parameter is ignored when redirectToStdout is set.
   maxEntrySize?: number;
-
   // A default global callback to be used for {@link LoggingBunyan} write calls
   // when callback is not supplied by caller in function parameters
   defaultCallback?: ApiResponseCallback;
+  /**
+   * Boolen flag that opts-in redirecting the output to STDOUT instead of ingesting logs to Cloud
+   * Logging using Logging API. Defaults to {@code false}. Redirecting logs can be used in
+   * Google Cloud environments with installed logging agent to delegate log ingestions to the
+   * agent. Redirected logs are formatted as one line Json string following the structured logging guidelines.
+   */
+  redirectToStdout?: boolean;
 }
 
 export interface MonitoredResource {

--- a/system-test/logging-bunyan.ts
+++ b/system-test/logging-bunyan.ts
@@ -20,7 +20,7 @@ import * as bunyan from 'bunyan';
 import * as uuid from 'uuid';
 import * as types from '../src/types/core';
 import {ErrorsApiTransport} from './errors-transport';
-import {Logging} from '@google-cloud/logging';
+import {Logging, LogSync} from '@google-cloud/logging';
 
 const logging = new Logging();
 import {LoggingBunyan} from '../src/index';
@@ -45,6 +45,14 @@ describe('LoggingBunyan', function () {
   const logger = bunyan.createLogger({
     name: 'google-cloud-node-system-test',
     streams: [loggingBunyan.stream('info')],
+  });
+
+  it('should create LoggingBunyan with LogSync', () => {
+    const loggingBunyan = new LoggingBunyan({
+      logName: LOG_NAME,
+      redirectToStdout: true,
+    });
+    assert.ok(loggingBunyan.cloudLog instanceof LogSync);
   });
 
   it('should properly write log entries', async function () {

--- a/test/index.ts
+++ b/test/index.ts
@@ -264,7 +264,7 @@ describe('logging-bunyan', () => {
     });
 
     it('should properly create an entry', done => {
-      loggingBunyan.stackdriverLog.entry = (
+      loggingBunyan.cloudLog.entry = (
         entryMetadata: types.StackdriverEntryMetadata,
         record: types.StackdriverEntryMetadata
       ) => {
@@ -284,7 +284,7 @@ describe('logging-bunyan', () => {
       const recordWithMsg = Object.assign({msg: 'msg'}, RECORD);
       const recordWithMessage = Object.assign({message: 'msg'}, RECORD);
 
-      loggingBunyan.stackdriverLog.entry = (
+      loggingBunyan.cloudLog.entry = (
         entryMetadata: types.StackdriverEntryMetadata,
         record: types.StackdriverEntryMetadata
       ) => {
@@ -317,7 +317,7 @@ describe('logging-bunyan', () => {
         RECORD
       );
 
-      loggingBunyan.stackdriverLog.entry = (
+      loggingBunyan.cloudLog.entry = (
         entryMetadata: types.StackdriverEntryMetadata,
         record_: types.StackdriverEntryMetadata
       ) => {
@@ -340,7 +340,7 @@ describe('logging-bunyan', () => {
         RECORD
       );
 
-      loggingBunyan.stackdriverLog.entry = (
+      loggingBunyan.cloudLog.entry = (
         entryMetadata: types.StackdriverEntryMetadata,
         record_: types.StackdriverEntryMetadata
       ) => {
@@ -362,7 +362,7 @@ describe('logging-bunyan', () => {
         RECORD
       );
 
-      loggingBunyan.stackdriverLog.entry = (
+      loggingBunyan.cloudLog.entry = (
         entryMetadata: types.StackdriverEntryMetadata,
         record: string | types.BunyanLogRecord
       ) => {
@@ -382,7 +382,7 @@ describe('logging-bunyan', () => {
     it('should promote properly formatted labels to metadata', done => {
       const labels = {key: 'value', 0: 'value2'};
       const recordWithLabels = {...RECORD, labels};
-      loggingBunyan.stackdriverLog.entry = (
+      loggingBunyan.cloudLog.entry = (
         entryMetadata: types.StackdriverEntryMetadata,
         record: string | types.BunyanLogRecord
       ) => {
@@ -396,7 +396,7 @@ describe('logging-bunyan', () => {
     it('should not promote ill-formatted labels to metadata', done => {
       const labels = {key: -1}; // values must be strings.
       const recordWithLabels = {...RECORD, labels};
-      loggingBunyan.stackdriverLog.entry = (
+      loggingBunyan.cloudLog.entry = (
         entryMetadata: types.StackdriverEntryMetadata,
         record: string | types.BunyanLogRecord
       ) => {
@@ -417,7 +417,7 @@ describe('logging-bunyan', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (recordWithTrace as any)[loggingBunyanLib.LOGGING_SAMPLED_KEY] = true;
 
-      loggingBunyan.stackdriverLog.entry = (
+      loggingBunyan.cloudLog.entry = (
         entryMetadata: types.StackdriverEntryMetadata,
         record: string | types.BunyanLogRecord
       ) => {
@@ -441,7 +441,7 @@ describe('logging-bunyan', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (recordWithTrace as any)[loggingBunyanLib.LOGGING_SAMPLED_KEY] = false;
 
-      loggingBunyan.stackdriverLog.entry = (
+      loggingBunyan.cloudLog.entry = (
         entryMetadata: types.StackdriverEntryMetadata,
         record: string | types.BunyanLogRecord
       ) => {
@@ -630,11 +630,11 @@ describe('logging-bunyan', () => {
     it('should write the record to the log instance', done => {
       const entry = {};
 
-      loggingBunyan.stackdriverLog.entry = () => {
+      loggingBunyan.cloudLog.entry = () => {
         return entry;
       };
 
-      loggingBunyan.stackdriverLog.write =
+      loggingBunyan.cloudLog.write =
         // Writable.write used 'any' in function signature.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (entries: any, callback: Function) => {
@@ -647,22 +647,19 @@ describe('logging-bunyan', () => {
 
     it('should write the record and call default callback', done => {
       let isCallbackCalled = false;
-      loggingBunyan.stackdriverLog.entry = () => {
+      loggingBunyan.cloudLog.entry = () => {
         return {};
       };
       loggingBunyan.defaultCallback = () => {
         isCallbackCalled = true;
       };
-      loggingBunyan.stackdriverLog.write =
+      loggingBunyan.cloudLog.write =
         // Writable.write used 'any' in function signature.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (entries: any, callback: Function) => {
           callback();
         };
-
-      loggingBunyan._write(RECORD, '', () => {
-        throw Error('Should never be called!');
-      });
+      loggingBunyan._write(RECORD, '', () => {});
       assert.strictEqual(isCallbackCalled, true);
       done();
     });
@@ -690,11 +687,11 @@ describe('logging-bunyan', () => {
     it('should write the records to the log instance', done => {
       const entry = {};
 
-      loggingBunyan.stackdriverLog.entry = () => {
+      loggingBunyan.cloudLog.entry = () => {
         return entry;
       };
 
-      loggingBunyan.stackdriverLog.write =
+      loggingBunyan.cloudLog.write =
         // Writable.write used 'any' in function signature.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (entries: any, callback: Function) => {

--- a/test/middleware/test-express.ts
+++ b/test/middleware/test-express.ts
@@ -32,10 +32,10 @@ let passedOptions: Array<MiddlewareOptions | undefined>;
 
 class FakeLoggingBunyan {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  stackdriverLog: any;
+  cloudLog: any;
   constructor(options: MiddlewareOptions) {
     passedOptions.push(options);
-    this.stackdriverLog = {
+    this.cloudLog = {
       logging: {
         auth: {
           async getProjectId() {


### PR DESCRIPTION
There are problems reported by users about inability to flush logging data in serverless environments like Cloud Functions reported in [603](https://github.com/googleapis/nodejs-logging-bunyan/issues/603). The idea is to add support to print structured logging to STDOUT, so the logging output would be picked up by Cloud Logging Agent in Google Cloud managed environment.

Fixes #[536](https://github.com/googleapis/nodejs-logging-bunyan/issues/536) 🦕
