### PR TITLE
feat: Add support for library instrumentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "precompile": "gts clean"
   },
   "dependencies": {
-    "@google-cloud/logging": "^10.0.0",
+    "arrify": "^2.0.1",
+    "@google-cloud/logging": "^10.0.2",
     "google-auth-library": "^8.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "precompile": "gts clean"
   },
   "dependencies": {
-    "arrify": "^2.0.1",
     "@google-cloud/logging": "^10.0.2",
     "google-auth-library": "^8.0.2"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,12 @@
 
 import {Writable} from 'stream';
 import * as express from './middleware/express';
+import {
+  setInstrumentationStatus,
+  createDiagnosticEntry,
+} from '@google-cloud/logging/build/src/utils/instrumentation';
+import path = require('path');
+import arrify = require('arrify');
 
 // Export the express middleware as 'express'.
 export {express};
@@ -63,6 +69,9 @@ export const LOGGING_SPAN_KEY = 'logging.googleapis.com/spanId';
  * before it gets written to the Cloud logging API.
  */
 export const LOGGING_SAMPLED_KEY = 'logging.googleapis.com/trace_sampled';
+
+// The variable to hold cached library version
+let libraryVersion: string;
 
 /**
  * Gets the current fully qualified trace ID when available from the
@@ -426,6 +435,23 @@ export class LoggingBunyan extends Writable {
    * @param callback The callback supplied by Writable.write
    */
   _writeCall(entries: Entry | Entry[], callback: Function) {
+    // First create instrumentation record if it is never written before
+    if (!setInstrumentationStatus(true)) {
+      let instrumentationEntry = createDiagnosticEntry(
+        'nodejs-bunyan',
+        this.getNodejsLibraryVersion()
+      );
+      // Update instrumentation record resource and logName
+      instrumentationEntry.metadata.resource = this.resource;
+      instrumentationEntry.metadata.severity = 'INFO';
+      instrumentationEntry = (
+        this.redirectToStdout
+          ? (this.cloudLog as LogSync)
+          : (this.cloudLog as Log)
+      ).entry(instrumentationEntry.metadata, instrumentationEntry.data);
+      entries = arrify(entries);
+      entries.push(instrumentationEntry);
+    }
     if (this.redirectToStdout) {
       (this.cloudLog as LogSync).write(entries);
       // The LogSync class does not supports callback. However if callback provided and
@@ -434,6 +460,22 @@ export class LoggingBunyan extends Writable {
     } else {
       (this.cloudLog as Log).write(entries, this.generateCallback(callback));
     }
+  }
+
+  /**
+   * Method used to retrieve the current logging-bunyan library version
+   * @returns The version of this library
+   */
+  getNodejsLibraryVersion() {
+    if (libraryVersion) {
+      return libraryVersion;
+    }
+    libraryVersion = require(path.resolve(
+      __dirname,
+      '../../',
+      'package.json'
+    )).version;
+    return libraryVersion;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,6 @@ import {
   createDiagnosticEntry,
 } from '@google-cloud/logging/build/src/utils/instrumentation';
 import path = require('path');
-import arrify = require('arrify');
 
 // Export the express middleware as 'express'.
 export {express};
@@ -436,7 +435,8 @@ export class LoggingBunyan extends Writable {
    */
   _writeCall(entries: Entry | Entry[], callback: Function) {
     // First create instrumentation record if it is never written before
-    if (!setInstrumentationStatus(true)) {
+    const alreadyWritten = setInstrumentationStatus(true);
+    if (!alreadyWritten) {
       let instrumentationEntry = createDiagnosticEntry(
         'nodejs-bunyan',
         this.getNodejsLibraryVersion()
@@ -449,7 +449,7 @@ export class LoggingBunyan extends Writable {
           ? (this.cloudLog as LogSync)
           : (this.cloudLog as Log)
       ).entry(instrumentationEntry.metadata, instrumentationEntry.data);
-      entries = arrify(entries);
+      entries = Array.isArray(entries) ? entries : [entries];
       entries.push(instrumentationEntry);
     }
     if (this.redirectToStdout) {

--- a/system-test/logging-bunyan.ts
+++ b/system-test/logging-bunyan.ts
@@ -68,6 +68,7 @@ describe('LoggingBunyan', function () {
       WRITE_CONSISTENCY_DELAY_MS
     );
     assert.strictEqual(entries.length, 2);
+    let isDiagnosticPresent = false;
     entries.forEach(entry => {
       assert.ok(entry.data);
       if (
@@ -81,12 +82,16 @@ describe('LoggingBunyan', function () {
           instrumentation.INSTRUMENTATION_SOURCE_KEY
         ];
         assert.equal(info[0].name, 'nodejs');
+        assert.ok(info[0].version.includes('.'));
         assert.equal(info[1].name, 'nodejs-bunyan');
+        assert.ok(info[1].version.includes('.'));
+        isDiagnosticPresent = true;
       } else {
         const data = entry.data as {message: string};
         assert.ok(data.message.includes(MESSAGE));
       }
     });
+    assert.ok(isDiagnosticPresent);
   });
 
   it('should properly write log entries', async function () {

--- a/system-test/logging-bunyan.ts
+++ b/system-test/logging-bunyan.ts
@@ -28,7 +28,7 @@ import delay from 'delay';
 import * as instrumentation from '@google-cloud/logging/build/src/utils/instrumentation';
 
 const WRITE_CONSISTENCY_DELAY_MS = 90000;
-const MESSAGE = "Diagnostic test";
+const MESSAGE = 'Diagnostic test';
 
 const UUID = uuid.v4();
 function logName(name: string) {
@@ -57,7 +57,7 @@ describe('LoggingBunyan', function () {
     assert.ok(loggingBunyan.cloudLog instanceof LogSync);
   });
 
-  it('should write diagnostic entry', async function () {
+  it('should write diagnostic entry', async () => {
     instrumentation.setInstrumentationStatus(false);
     const start = Date.now();
     logger.info(MESSAGE);
@@ -72,22 +72,21 @@ describe('LoggingBunyan', function () {
       assert.ok(entry.data);
       if (
         Object.prototype.hasOwnProperty.call(
-          (entry.data as any),
+          entry.data as any,
           instrumentation.DIAGNOSTIC_INFO_KEY
         )
       ) {
-        const info =
-          (entry.data as any)[instrumentation.DIAGNOSTIC_INFO_KEY][
-            instrumentation.INSTRUMENTATION_SOURCE_KEY
-          ];
+        const info = (entry.data as any)[instrumentation.DIAGNOSTIC_INFO_KEY][
+          instrumentation.INSTRUMENTATION_SOURCE_KEY
+        ];
         assert.equal(info[0].name, 'nodejs');
         assert.equal(info[1].name, 'nodejs-bunyan');
       } else {
         const data = entry.data as {message: string};
         assert.ok(data.message.includes(MESSAGE));
       }
-    });    
-  });  
+    });
+  });
 
   it('should properly write log entries', async function () {
     this.retries(3);

--- a/system-test/logging-bunyan.ts
+++ b/system-test/logging-bunyan.ts
@@ -236,7 +236,6 @@ describe('LoggingBunyan', function () {
       );
       const errEvent = errors[0];
 
-      console.log(`The entries are: ${JSON.stringify(errEvent)}`);
       assert.strictEqual(errEvent.serviceContext.service, SERVICE);
       assert(errEvent.message.startsWith(`Error: ${message}`));
     });

--- a/system-test/logging-bunyan.ts
+++ b/system-test/logging-bunyan.ts
@@ -28,7 +28,7 @@ import delay from 'delay';
 import * as instrumentation from '@google-cloud/logging/build/src/utils/instrumentation';
 
 const WRITE_CONSISTENCY_DELAY_MS = 90000;
-const MESSAGE = "Diagnostic test";
+const MESSAGE = 'Diagnostic test';
 
 const UUID = uuid.v4();
 function logName(name: string) {
@@ -57,7 +57,7 @@ describe('LoggingBunyan', function () {
     assert.ok(loggingBunyan.cloudLog instanceof LogSync);
   });
 
-  it('should write diagnostic entry', async function () {
+  it('should write diagnostic entry', async () => {
     instrumentation.setInstrumentationStatus(false);
     const start = Date.now();
     logger.info(MESSAGE);
@@ -72,22 +72,22 @@ describe('LoggingBunyan', function () {
       assert.ok(entry.data);
       if (
         Object.prototype.hasOwnProperty.call(
-          (entry.data as any),
+          entry.data,
           instrumentation.DIAGNOSTIC_INFO_KEY
         )
       ) {
-        const info =
-          (entry.data as any)[instrumentation.DIAGNOSTIC_INFO_KEY][
-            instrumentation.INSTRUMENTATION_SOURCE_KEY
-          ];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const info = (entry.data as any)[instrumentation.DIAGNOSTIC_INFO_KEY][
+          instrumentation.INSTRUMENTATION_SOURCE_KEY
+        ];
         assert.equal(info[0].name, 'nodejs');
         assert.equal(info[1].name, 'nodejs-bunyan');
       } else {
         const data = entry.data as {message: string};
         assert.ok(data.message.includes(MESSAGE));
       }
-    });    
-  });  
+    });
+  });
 
   it('should properly write log entries', async function () {
     this.retries(3);


### PR DESCRIPTION
This feature provides an ability to log extra entry with diagnostics structure which contains logging library information. Such entry is logged only once when first entry is written by a process using logging library.

Fixes #[630](https://github.com/googleapis/nodejs-logging-bunyan/issues/630) 🦕

