### PR TITLE
fix: Update latest logging-nodejs to repaire google-gax vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "precompile": "gts clean"
   },
   "dependencies": {
-    "@google-cloud/logging": "^10.1.1",
+    "@google-cloud/logging": "^10.1.4",
     "google-auth-library": "^8.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Update to latest logging-nodejs which contains latest google-gax library 