### PR TITLE
fix: skip parent request entry on cloud run

### DIFF
--- a/.readme-partials.yml
+++ b/.readme-partials.yml
@@ -166,6 +166,8 @@ body: |-
   would be picked up by the Cloud Logging Agent running in Google Cloud managed environment. 
   Note that there is also a `useMessageField` option which controls if "message" field is used to store 
   structured, non-text data inside `jsonPayload` field when `redirectToStdout` is set. By default `useMessageField` is always `true`.
+  Set the `skipParentEntryForCloudRun` option to skip creating an entry for the request itself as Cloud Run already automatically creates
+  such log entries. This might become the default behaviour in a next major version.
 
   ```js
   // Imports the Google Cloud client library for Bunyan

--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ decrease logging record loss upon execution termination - since all logs are wri
 would be picked up by the Cloud Logging Agent running in Google Cloud managed environment. 
 Note that there is also a `useMessageField` option which controls if "message" field is used to store 
 structured, non-text data inside `jsonPayload` field when `redirectToStdout` is set. By default `useMessageField` is always `true`.
+Set the `skipParentEntryForCloudRun` option to skip creating an entry for the request itself as Cloud Run already automatically creates
+such log entries. This might become the default behaviour in a next major version.
 
 ```js
 // Imports the Google Cloud client library for Bunyan

--- a/test/middleware/test-express.ts
+++ b/test/middleware/test-express.ts
@@ -125,10 +125,15 @@ describe('middleware/express', () => {
     assert.strictEqual(passedProjectId, FAKE_PROJECT_ID);
   });
 
-  [GCPEnv.APP_ENGINE, GCPEnv.CLOUD_FUNCTIONS].forEach(env => {
+  [GCPEnv.APP_ENGINE, GCPEnv.CLOUD_FUNCTIONS, GCPEnv.CLOUD_RUN].forEach(env => {
     it(`should not generate the request logger on ${env}`, async () => {
       authEnvironment = env;
-      await middleware();
+      if (env === GCPEnv.CLOUD_RUN) {
+        // Cloud Run needs explicit option flag to enable this behavior until we can make breaking change in next major version
+        await middleware({skipParentEntryForCloudRun: true});
+      } else {
+        await middleware();
+      }
       assert.ok(passedOptions);
       assert.strictEqual(passedOptions.length, 1);
       // emitRequestLog parameter to makeChildLogger should be undefined.


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-logging-bunyan/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #626

We also suffer from this issue. As a (dirty) workaround we have no added the following code to our own codebase:
```
// workaround for https://github.com/googleapis/nodejs-logging-bunyan/issues/626 to let lib know we are running in GCP
if (process.env.K_SERVICE && !process.env.GAE_SERVICE) {
    // trick library into thinking we run on AppEngine
    process.env.GAE_SERVICE = process.env.K_SERVICE;
}
```
