### PR TITLE
chore: replace ReturnType with type import

### DIFF
--- a/src/middleware/express.ts
+++ b/src/middleware/express.ts
@@ -18,6 +18,7 @@ import {
   middleware as commonMiddleware,
 } from '@google-cloud/logging';
 import * as bunyan from 'bunyan';
+import type * as Logger from 'bunyan';
 import {GCPEnv} from 'google-auth-library';
 
 import {
@@ -29,10 +30,6 @@ import {
 import * as types from '../types/core';
 
 export const APP_LOG_SUFFIX = 'applog';
-
-// @types/bunyan doesn't export Logger. Access it via ReturnType on
-// createLogger.
-export type Logger = ReturnType<typeof bunyan.createLogger>;
 
 export interface MiddlewareOptions extends types.Options {
   level?: types.LogLevel;


### PR DESCRIPTION
This doesn't really fix an issue but I happened to notice the awkward use of `ReturnType` where a simple type import does the same.