### PR TITLE
fix: Fix rest links with the correct gRPC links used by library.

### DIFF
--- a/.readme-partials.yml
+++ b/.readme-partials.yml
@@ -61,7 +61,7 @@ body: |-
 
   ### Error Reporting
 
-  Any `Error` objects you log at severity `error` or higher can automatically be picked up by [Cloud Error Reporting][error-reporting] if you have specified a `serviceContext.service` when instantiating a `LoggingBunyan` instance:
+  Any `Error` objects you log at severity `error` or higher can automatically be picked up by [Cloud Error Reporting](https://cloud.google.com/error-reporting/) if you have specified a `serviceContext.service` when instantiating a `LoggingBunyan` instance:
 
   ```javascript
   const loggingBunyan = new LoggingBunyan({
@@ -76,14 +76,14 @@ body: |-
 
   It is an error to specify a `serviceContext` but not specify `serviceContext.service`.
 
-  Make sure to add logs to your [uncaught exception][uncaught] and [unhandled rejection][unhandled] handlers if you want to see those errors too.
+  Make sure to add logs to your [uncaught exception](https://nodejs.org/api/process.html#process_event_uncaughtexception) and [unhandled rejection](https://nodejs.org/api/process.html#process_event_unhandledrejection) handlers if you want to see those errors too.
 
   You may also want to see the [@google-cloud/error-reporting][@google-cloud/error-reporting] module which provides direct access to the Error Reporting API.
 
   ### LogEntry Labels
 
   If the bunyan log record contains a label property where all the values are strings, we automatically promote that
-  property to be the [`LogEntry.labels`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry) value rather
+  property to be the [`LogEntry.labels`](https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.v2#logentry) value rather
   than being one of the properties in the `payload` fields. This makes it easier to filter the logs in the UI using the labels.
 
   ```javascript
@@ -94,7 +94,7 @@ body: |-
 
   ### Formatting Request Logs
 
-  To format your request logs you can provide a `httpRequest` property on the bunyan metadata you provide along with the log message. We will treat this as the [`HttpRequest`][http-request-message] message and Cloud logging will show this as a request log. Example:
+  To format your request logs you can provide a `httpRequest` property on the bunyan metadata you provide along with the log message. We will treat this as the [`HttpRequest`](https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.type#google.logging.type.HttpRequest) message and Cloud logging will show this as a request log. Example:
 
   ![Request Log Example](https://raw.githubusercontent.com/googleapis/nodejs-logging-bunyan/master/doc/images/request-log.png)
 
@@ -110,7 +110,7 @@ body: |-
   }, req.path);
   ```
 
-  The `httpRequest` property must be a properly formatted [`HttpRequest`][http-request-message] message. (Note: the linked protobuf documentation shows `snake_case` property names, but in JavaScript one needs to provide property names in `camelCase`.)
+  The `httpRequest` property must be a properly formatted [`HttpRequest`](https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.type#google.logging.type.HttpRequest) message. (Note: the linked protobuf documentation shows `snake_case` property names, but in JavaScript one needs to provide property names in `camelCase`.)
 
   ### Correlating Logs with Traces
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ startServer();
 
 ### Error Reporting
 
-Any `Error` objects you log at severity `error` or higher can automatically be picked up by [Cloud Error Reporting][error-reporting] if you have specified a `serviceContext.service` when instantiating a `LoggingBunyan` instance:
+Any `Error` objects you log at severity `error` or higher can automatically be picked up by [Cloud Error Reporting](https://cloud.google.com/error-reporting/) if you have specified a `serviceContext.service` when instantiating a `LoggingBunyan` instance:
 
 ```javascript
 const loggingBunyan = new LoggingBunyan({
@@ -158,7 +158,7 @@ const loggingBunyan = new LoggingBunyan({
 
 It is an error to specify a `serviceContext` but not specify `serviceContext.service`.
 
-Make sure to add logs to your [uncaught exception][uncaught] and [unhandled rejection][unhandled] handlers if you want to see those errors too.
+Make sure to add logs to your [uncaught exception](https://nodejs.org/api/process.html#process_event_uncaughtexception) and [unhandled rejection](https://nodejs.org/api/process.html#process_event_unhandledrejection) handlers if you want to see those errors too.
 
 You may also want to see the [@google-cloud/error-reporting][@google-cloud/error-reporting] module which provides direct access to the Error Reporting API.
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ You may also want to see the [@google-cloud/error-reporting][@google-cloud/error
 ### LogEntry Labels
 
 If the bunyan log record contains a label property where all the values are strings, we automatically promote that
-property to be the [`LogEntry.labels`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry) value rather
+property to be the [`LogEntry.labels`](https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.v2#logentry) value rather
 than being one of the properties in the `payload` fields. This makes it easier to filter the logs in the UI using the labels.
 
 ```javascript
@@ -176,7 +176,7 @@ All the label values must be strings for this automatic promotion to work. Other
 
 ### Formatting Request Logs
 
-To format your request logs you can provide a `httpRequest` property on the bunyan metadata you provide along with the log message. We will treat this as the [`HttpRequest`][http-request-message] message and Cloud logging will show this as a request log. Example:
+To format your request logs you can provide a `httpRequest` property on the bunyan metadata you provide along with the log message. We will treat this as the [`HttpRequest`](https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.type#google.logging.type.HttpRequest) message and Cloud logging will show this as a request log. Example:
 
 ![Request Log Example](https://raw.githubusercontent.com/googleapis/nodejs-logging-bunyan/master/doc/images/request-log.png)
 
@@ -192,7 +192,7 @@ logger.info({
 }, req.path);
 ```
 
-The `httpRequest` property must be a properly formatted [`HttpRequest`][http-request-message] message. (Note: the linked protobuf documentation shows `snake_case` property names, but in JavaScript one needs to provide property names in `camelCase`.)
+The `httpRequest` property must be a properly formatted [`HttpRequest`](https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.type#google.logging.type.HttpRequest) message. (Note: the linked protobuf documentation shows `snake_case` property names, but in JavaScript one needs to provide property names in `camelCase`.)
 
 ### Correlating Logs with Traces
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,8 @@ export function getCurrentTraceFromAgent() {
  *     automatically, but you may optionally specify a specific monitored
  *     resource. For more information, see the
  *     [official documentation]{@link
- * https://cloud.google.com/logging/docs/api/reference/rest/v2/MonitoredResource}
+ * https://cloud.google.com/monitoring/api/ref_v3/rpc/google.api#google.api.MonitoredResource}
+ * 
  * @param {object} [options.serviceContext] For logged errors, we provide this
  *     as the service context. For more information see
  *     [this guide]{@link
@@ -283,7 +284,7 @@ export class LoggingBunyan extends Writable {
 
     // If the record contains a httpRequest property, provide it on the entry
     // metadata. This allows Stackdriver to use request log formatting.
-    // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest
+    // https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.type#google.logging.type.HttpRequest
     // Note that the httpRequest field must properly validate as a HttpRequest
     // proto message, or the log entry would be rejected by the API. We do no
     // validation here.

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,7 @@ export function getCurrentTraceFromAgent() {
  *     resource. For more information, see the
  *     [official documentation]{@link
  * https://cloud.google.com/monitoring/api/ref_v3/rpc/google.api#google.api.MonitoredResource}
- * 
+ *
  * @param {object} [options.serviceContext] For logged errors, we provide this
  *     as the service context. For more information see
  *     [this guide]{@link


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-logging-bunyan/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #685 🦕
 Updating google apis links since library uses the gRPC / Protobuf transport. This has been causing some confusions when there is type/format difference regarding the same property between Rest and gRPC.
