### PR TITLE
feat: enable custom json fields truncation for bunyan

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -150,7 +150,10 @@ export function getCurrentTraceFromAgent() {
  *     attempted before returning the error.
  * @param {constructor} [options.promise] Custom promise module to use instead
  *     of native Promises.
- *
+ * @param {constructor} [options.promise] Custom promise module to use instead
+ *     of native Promises.
+ * @param {number} [options.maxEntrySize] Max size limit of a log entry.
+ * @param {string[]} [options.jsonFieldsToTruncate] A list of JSON properties at the given full path to be truncated.
  * @example Import the client library
  * ```
  * const {LoggingBunyan} = require('@google-cloud/logging-bunyan');
@@ -199,6 +202,7 @@ export class LoggingBunyan extends Writable {
         // 250,000 has been chosen to keep us comfortably within the
         // 256,000 limit.
         maxEntrySize: options.maxEntrySize || 250000,
+        jsonFieldsToTruncate: options.jsonFieldsToTruncate,
       });
     } else {
       const logSyncOptions: LogSyncOptions = {

--- a/src/types/core.d.ts
+++ b/src/types/core.d.ts
@@ -78,9 +78,16 @@ export interface Options {
    * Defaults to `logging.googleapis.com`.
    */
   apiEndpoint?: string;
-  // An attempt will be made to truncate messages larger than maxEntrySize.
-  // Please note that this parameter is ignored when redirectToStdout is set.
+  /**
+   * An attempt will be made to truncate messages larger than maxEntrySize.
+   * Please note that this parameter is ignored when redirectToStdout is set.
+   */
   maxEntrySize?: number;
+  /**
+   * A list of JSON properties at the given full path to be truncated.
+   * Received values will be prepended to predefined list in the order received and duplicates discarded.
+   */
+  jsonFieldsToTruncate?: string[];
   // A default global callback to be used for {@link LoggingBunyan} write calls
   // when callback is not supplied by caller in function parameters
   defaultCallback?: ApiResponseCallback;

--- a/test/index.ts
+++ b/test/index.ts
@@ -153,10 +153,13 @@ describe('logging-bunyan', () => {
       assert.strictEqual(fakeLoggingOptions_, OPTIONS);
       assert.strictEqual(fakeLogName_, OPTIONS.logName);
     });
-    
+
     it('should localize Log instance using provided jsonFieldsToTruncate in options', () => {
       assert.strictEqual(fakeLoggingOptions_, OPTIONS);
-      assert.strictEqual(fakeLogOptions_.jsonFieldsToTruncate, OPTIONS.jsonFieldsToTruncate);
+      assert.strictEqual(
+        fakeLogOptions_.jsonFieldsToTruncate,
+        OPTIONS.jsonFieldsToTruncate
+      );
     });
 
     it('should localize Log instance using default name, removeCircular and maxEntrySize options', () => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -26,6 +26,7 @@ interface Options {
     service: string;
   };
   apiEndpoint: string;
+  jsonFieldsToTruncate: string[];
 }
 interface FakeLogType {
   entry?: () => void;
@@ -106,6 +107,9 @@ describe('logging-bunyan', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let loggingBunyan: any;
 
+  const TRUNCATE_FIELD =
+    'jsonPayload.fields.metadata.structValue.fields.custom.stringValue';
+
   const OPTIONS = {
     logName: 'log-name',
     resource: {},
@@ -113,6 +117,7 @@ describe('logging-bunyan', () => {
       service: 'fake-service',
     },
     apiEndpoint: 'fake.local',
+    jsonFieldsToTruncate: [TRUNCATE_FIELD],
   };
 
   const RECORD = {
@@ -148,8 +153,13 @@ describe('logging-bunyan', () => {
       assert.strictEqual(fakeLoggingOptions_, OPTIONS);
       assert.strictEqual(fakeLogName_, OPTIONS.logName);
     });
+    
+    it('should localize Log instance using provided jsonFieldsToTruncate in options', () => {
+      assert.strictEqual(fakeLoggingOptions_, OPTIONS);
+      assert.strictEqual(fakeLogOptions_.jsonFieldsToTruncate, OPTIONS.jsonFieldsToTruncate);
+    });
 
-    it('should localize Log instance using default name, options', () => {
+    it('should localize Log instance using default name, removeCircular and maxEntrySize options', () => {
       const optionsWithoutLogName: Options = Object.assign({}, OPTIONS);
       delete optionsWithoutLogName.logName;
       new loggingBunyanLib.LoggingBunyan(optionsWithoutLogName);
@@ -158,6 +168,7 @@ describe('logging-bunyan', () => {
       assert.deepStrictEqual(fakeLogOptions_, {
         removeCircular: true,
         maxEntrySize: 250000,
+        jsonFieldsToTruncate: [TRUNCATE_FIELD],
       });
     });
 


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-logging-bunyan/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #682 🦕

Expose the ability to provide customized list of entries to be truncated to be consistent with the behavior in [nodejs-logging](https://github.com/googleapis/nodejs-logging/pull/1177). The list will be prepended to default existing list in nodejs-logging, and custom-defined fields will be truncated first. 
