### PR TITLE
chore: replace old nodejs teams with cloud-sdk-nodejs-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs @jsteam
+*     @googleapis/cloud-sdk-nodejs-team @jsteam

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,4 +1,4 @@
 assign_issues:
-  - googleapis/yoshi-nodejs
+  - googleapis/cloud-sdk-nodejs-team
 assign_prs:
-  - googleapis/yoshi-nodejs
+  - googleapis/cloud-sdk-nodejs-team

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,6 +9,6 @@
   "repo": "googleapis/nodejs-logging-bunyan",
   "distribution_name": "@google-cloud/logging-bunyan",
   "api_id": "logging.googleapis.com",
-  "codeowner_team": "@googleapis/yoshi-nodejs",
+  "codeowner_team": "@googleapis/cloud-sdk-nodejs-team",
   "library_type": "OTHER"
 }


### PR DESCRIPTION
b/479541676